### PR TITLE
DE24710: Show all kanban cards when printing

### DIFF
--- a/src/apps/kanban/KanbanApp.less
+++ b/src/apps/kanban/KanbanApp.less
@@ -32,3 +32,17 @@
 .kanban {
   overflow-y: hidden;
 }
+
+.print-page {
+  .cardboard {
+    // needs !important to override inline style
+    height: auto !important; // So print view doesn't cut off the cards
+
+    .fixed-header-card-board-body-container {
+      & > table {
+        position: absolute; // So that there isn't a page-break between the column headers and the actual columns
+        width: calc(~"100% - 24px"); // correct alignment
+      }
+    }
+  }
+}


### PR DESCRIPTION
#### What does this PR do?

Fixes a bug where the Kanban board print page would cut off any cards that were below the fold.

#### Any background context you want to provide?
In order to show all the cards, the basic fix is just to override the height to be auto, so it will expand to the full height of the content.

Unfortunately, due to the headers and the body of the cards being implemented with two different tables, this creates a big page-break between the two when printing. The absolute positioning was the only way I could successfully get around that issue (setting `avoid` for the various css page-break properties didn't work, among other attempts). Unfortunately, because of the page padding this in turn caused a mis-alignment that is accounted for with the width `calc`. This feels really dirty, but I couldn't find any cleaner options without making pretty substantial changes.

#### Where should the reviewer start?
The one file

#### Steps to reproduce:
 - add kanban board app to custom page or dashboard
 - ensure it has more content than can be currently seen on the screen
 - click and select print

#### How should this be manually tested?

* Cross-browser
* Test different board configurations
* Are there other print views that could have cardboards? Check those

#### What are the relevant tickets?

[DE24710](https://rally1.rallydev.com/#/23112780161d/detail/defect/36392656189)

#### Screenshots, if appropriate. [:link:](http://recordit.co/)

| *Before* | *After* |
| ----------- | --------- |
| ![before](https://cloud.githubusercontent.com/assets/5432102/10680999/3b5b65a8-78e2-11e5-9046-73d9dd1b8ce6.png) | ![after](https://cloud.githubusercontent.com/assets/5432102/10681032/909cd1f0-78e2-11e5-9e8b-3f84ff04d4c9.png) |



#### Definition of Done
* [x] Story __acceptance criteria__ updated if changed
* [x] Does not negatively impacting [__perceived performance__](https://docs.google.com/document/d/1j4AbGqGp_Le1SfQp3lp-pclk0ojQqZy7Cp-HbNq4i94)
* [x] Does not degrade __performance__ and meets feature performance requirements
* [ ] Renders properly in [__all supported browsers__](https://help.rallydev.com/supported-web-browsers)
* [ ] __Sufficiently rich data__ used during development to expose important data relationships
* [ ] __Code reviewed__ by someone who didn't write it
* [ ] __Automated tests__ written and passing at appropriate levels. (unit, integration, end-to-end, etc.)
> I don't know how to test this automatically (maybe when we have better visual diff testing?)
* [ ] No functional __regressions__ have been introduced

#### How does this PR make you feel? [:link:](http://giphy.com/categories/emotions/)

![Gross](https://media.giphy.com/media/Nm3mS4RKOhteg/giphy.gif)