### PR TITLE
fix(burndownChart): DE25375 render data when points are over 1000

### DIFF
--- a/src/apps/iterationtrackingboard/statsbanner/iterationprogresscharts/BurndownChart.js
+++ b/src/apps/iterationtrackingboard/statsbanner/iterationprogresscharts/BurndownChart.js
@@ -209,7 +209,7 @@
             // find the last <text element with orientation="vertical_down" attribute, that's the max y-axis 2 setting
             for (i = 0; i < texts.length; i++) {
                 if (texts[i].getAttribute("orientation") === "vertical_down") {
-                    this.chartComponentConfig.chartConfig.yAxis[1].max = (this._getElementValue(texts[i]) * 1);
+                    this.chartComponentConfig.chartConfig.yAxis[1].max = (this._getNumberFromXMLString(this._getElementValue(texts[i])));
                 }
             }
             this._configureYAxisIntervals();

--- a/src/apps/iterationtrackingboard/statsbanner/iterationprogresscharts/IterationProgressMixin.js
+++ b/src/apps/iterationtrackingboard/statsbanner/iterationprogresscharts/IterationProgressMixin.js
@@ -30,7 +30,7 @@
             }
             return element.text;
         },
-        
+
         _getStringValues: function (elements) {
             var i;
             var strings = [];
@@ -40,12 +40,20 @@
             return strings;
         },
 
+        _transformStringToNumber: function (element) {
+          return element.replace(',', '') * 1;
+        },
+
+        _getNumberFromXMLString: function (element) {
+          return this._transformStringToNumber(element.split(' ')[0]);
+        },
+
         _getNumberValues: function (elements) {
             var i;
             var numbers = [];
             for (i = 0; i < elements.length; i++) {
                 if(this._getElementValue(elements[i])) {
-                    numbers.push(this._getElementValue(elements[i]).split(' ')[0] * 1);
+                    numbers.push(this._getNumberFromXMLString(this._getElementValue(elements[i])));
                 } else {
                     numbers.push(0);
                 }


### PR DESCRIPTION
Parses the xml correctly when there is a comma in the string.
Also, could not get the chart to render if yAxis was set in the accepted series. There is already a 'global' yAxis setting, so that was removed...