### PR TITLE
DE26191: use project scope in IterationDashboard app

### DIFF
--- a/src/legacy/IterationDashboardMashup.html
+++ b/src/legacy/IterationDashboardMashup.html
@@ -1017,7 +1017,7 @@ RALLY.Mashup.SuperCustomizableChart = function(batchToolkit, timeboxOidList, tim
             var xhrFn = dojo.xhrGet;
 
             xhrFn({
-                url: "/slm/charts/itsc.sp?sid=&iterationOid=" + iterationOid + "&cpoid=" + projectOid,
+                url: "/slm/charts/itsc.sp?sid=&iterationOid=" + iterationOid + "&cpoid=" + projectOid + '&projectScopeUp=__PROJECT_SCOPING_UP__&projectScopeDown=__PROJECT_SCOPING_DOWN__',
                 handleAs: "xml",
                 load: function(xmlDoc) {
                     _createBurndownChartDatafromXML(xmlDoc);


### PR DESCRIPTION
On-Demand: between this run and the previous run, all tests passed - [http://almci/job/on-demand/view/AppSDK-AppCatalog-ALM%20On-Demand%201/job/appsdk-appcatalog-alm-on-demand-1/1801/](http://almci/job/on-demand/view/AppSDK-AppCatalog-ALM%20On-Demand%201/job/appsdk-appcatalog-alm-on-demand-1/1801/)

This fixes the IterationDashboard app's scoping settings. 

**The issue**:

The app's scoping settings do not override the global project scope settings (in project picker).

**The fix**:
We are already providing the relevant scoping information, we just need to send that along to the server when we make a request to the chart endpoint.

There aren't any tests for these legacy apps.