### PR TITLE
DE26411: ReleaseDashboard rolls up incorrectly

### DIFF
--- a/src/legacy/ReleaseDashboardMashup.html
+++ b/src/legacy/ReleaseDashboardMashup.html
@@ -2054,6 +2054,7 @@ RALLY.Mashup.TimeboxHealth = function(batchToolkit, callback) {
             theFilter = buildTimeboxQueryString(config.timeboxType, config.timeboxStart, config.timeboxEnd, config.timeboxName);
 
             for (artifactCountIndex = 0; artifactCountIndex * 200 < maxCount; artifactCountIndex++) {
+                queryArr = [];
                 if (storyCount > artifactCountIndex * 200) {
                     queryArr.push({
                         key: storyCountKey,


### PR DESCRIPTION
Added a line to clear queryArr as the code loops through multiple pages of 200 work items for each WSAPI request.  What was happening before was, if there were 250 stories, 2 requests would be made with storyCountKey, which was correct, but the grouped_defects_by_schedulestate key was still in queryArr, erroneously, for the 2nd request.  This had the effect of double-counting defects, as the customer discovered.  Crazy how long this bug has been there.