### PR TITLE
DE26292: Exclude milestones from closed projects

### DIFF
--- a/src/apps/chartbuilder/EaselSettingsTransformer.js
+++ b/src/apps/chartbuilder/EaselSettingsTransformer.js
@@ -2,6 +2,9 @@
 	var Ext = window.Ext4 || window.Ext;
 
 	Ext.define("Rally.apps.chartbuilder.EaselSettingsTransformer", {
+		requires: [
+				'Rally.data.wsapi.Filter'
+		],
 
 		settingsFieldTransformers: {
 			'milestone-picker': function(easelSettingsField) {
@@ -12,7 +15,17 @@
 					label: 'Milestone',
 					autoExpand: true,
 					selectOnFocus: true,
-					allowNoEntry: true
+					allowNoEntry: true,
+					storeConfig: {
+						remoteFilter: true,
+						filters: [
+							Ext.create('Rally.data.wsapi.Filter', {
+								property: 'Projects.state',
+								operator: '=',
+								value: "Open"
+							})
+						]
+					}
 				};
 			},
 			'project-picker': function(easelSettingsField) {

--- a/test/spec/chartbuilder/EaselSettingsTransformerSpec.coffee
+++ b/test/spec/chartbuilder/EaselSettingsTransformerSpec.coffee
@@ -1,7 +1,8 @@
 Ext = window.Ext4 || window.Ext
 
 Ext.require [
-	'Rally.apps.chartbuilder.EaselSettingsTransformer'
+	'Rally.apps.chartbuilder.EaselSettingsTransformer',
+	'Rally.data.wsapi.Filter'
 ]
 
 describe 'Rally.apps.chartbuilder.EaselSettingsTransformer', ->
@@ -11,7 +12,15 @@ describe 'Rally.apps.chartbuilder.EaselSettingsTransformer', ->
 			return Ext.create 'Rally.apps.chartbuilder.EaselSettingsTransformer'
 
 	beforeEach ->
+		@filter = [
+			config: {},
+			filter: @stub()
+		]
 		@xformer = @createXformer()
+		@stub(Ext, 'create').withArgs('Rally.data.wsapi.Filter').returns(@filter);
+
+	afterEach ->
+		Ext.create.restore()
 
 	it 'properly handles an empty settings fields list', ->
 		settingsFields = []
@@ -141,6 +150,9 @@ describe 'Rally.apps.chartbuilder.EaselSettingsTransformer', ->
 			autoExpand: true
 			selectOnFocus: true
 			allowNoEntry: true
+			storeConfig:
+				remoteFilter: true
+				filters: [@filter]
 		]
 
 		converted = @xformer.transform(settingsFields)


### PR DESCRIPTION
This changeset introduces a fix for [DE26292](https://rally1.rallydev.com/#/33116095857d/detail/defect/50039195116) where customers reported milestones within projects that are closed were being included in the milestone picker for the app settings panels of both the Milestone Burnup chart the the Milestone Cumulative Flow app.

:green_heart: [On-Demands](http://almci/job/on-demand/view/AppSDK-AppCatalog-ALM%20On-Demand%202/job/appsdk-appcatalog-alm-on-demand-2/1130/)

:green_heart: [2016.03.04 On-Demand](http://almci/job/on-demand/job/appsdk-appcatalog-alm-on-demand-2/1208/)