### PR TITLE
DE26290: Backlog - Add Child Inline - User Story 'Create + New' button not working

### DIFF
--- a/app-catalog.sublime-project
+++ b/app-catalog.sublime-project
@@ -14,7 +14,7 @@
 		],
 		"file_exclude_patterns": [
 			"*.iml",
-			"*.sublime-*",
+			"*.sublime-*"
 		]
 	}]
 }

--- a/src/apps/backlog/BacklogApp.js
+++ b/src/apps/backlog/BacklogApp.js
@@ -53,6 +53,7 @@
         getGridConfig: function () {
             return _.merge(this.callParent(arguments), {
                 inlineAddConfig: {
+                    enableAddPlusNewChildStories: false,
                     listeners: {
                         beforeeditorshow: function (addNewCmp, params) {
                             params.Iteration = 'u'; // explicitly set iteration to unscheduled so it doesn't default to current iteration on TPS editor.


### PR DESCRIPTION
Disable the Create + New button on the Backlog App

http://almci/job/on-demand/view/AppSDK-AppCatalog-ALM%20On-Demand%201/job/appsdk-appcatalog-alm-on-demand-1/1906/console