### PR TITLE
DE26192 - Fixes dates breaking portfolio item cumulative flow chart.

### DIFF
--- a/src/apps/charts/DateMixin.js
+++ b/src/apps/charts/DateMixin.js
@@ -31,6 +31,65 @@
             return new Date(dateObj.year, dateObj.month, dateObj.day);
         },
 
+        _getMonth: function(month) {
+            var monthMap = { jan: 0, feb: 1, mar: 2, apr: 3,
+                             may: 4, jun: 5, jul: 6, aug: 7,
+                             sep: 8, oct: 9, nov: 10, dec: 11 };
+            if(isNaN(month)) {
+                try {
+                    month = monthMap[month.toLowerCase()];
+                } catch(err) { }
+            } else {
+                month = parseInt(month, 10) - 1;
+            }
+
+            return month.toString();
+        },
+
+        _objectFromYearFirstDate: function (dateArray) {
+            var month = 0,
+                day = 0,
+                year = 0;
+
+            if (dateArray.length !== 3) {
+                return { year: year, month: month, day: day };
+            }
+
+            year = dateArray[0];
+            month = this._getMonth(dateArray[1]);
+            day = dateArray[2];
+
+            return {
+                year: year,
+                month: month,
+                day: day
+            };
+        },
+
+        _objectFromMonthFirstDate: function (dateArray) {
+            var month = 0,
+                day = 0,
+                year = 0;
+
+            if (dateArray.length !== 3) {
+                return { year: year, month: month, day: day };
+            }
+
+            month = this._getMonth(dateArray[0]);
+            day = dateArray[1];
+            year = dateArray[2];
+
+            return {
+                month: month,
+                day: day,
+                year: year
+            };
+        },
+
+        _shouldSplitOnDash: function (dateStr) {
+            return dateStr.split('-').length === 3;
+        },
+
         _splitDateParts: function (dateStr) {
             if (this._shouldSplitOnDash(dateStr)) {
                 return this._objectFromYearFirstDate(dateStr.split('-'));
@@ -38,38 +97,6 @@
             else {
                 return this._objectFromMonthFirstDate(dateStr.split('/'));
             }
-        },
-
-        _objectFromYearFirstDate: function (dateArray) {
-            if (dateArray.length !== 3) {
-                return { year: 0, month: 0, day: 0 };
-            }
-
-            dateArray[1] = (parseInt(dateArray[1], 10) - 1).toString();
-
-            return {
-                year: dateArray[0],
-                month: dateArray[1],
-                day: dateArray[2]
-            };
-        },
-
-        _objectFromMonthFirstDate: function (dateArray) {
-            if (dateArray.length !== 3) {
-                return { year: 0, month: 0, day: 0 };
-            }
-
-            dateArray[0] = (parseInt(dateArray[0], 10) - 1).toString();
-
-            return {
-                month: dateArray[0],
-                day: dateArray[1],
-                year: dateArray[2]
-            };
-        },
-
-        _shouldSplitOnDash: function (dateStr) {
-            return dateStr.split('-').length === 3;
         }
 
     });


### PR DESCRIPTION
#### What does this PR do?

Fixes **DE26192** which was preventing the Portfolio Item Cumulative Flow chart from loading.

#### Any background context you want to provide?

The root of the bug is that the `DateMixin` that we use in the app-catalog was not taking into account dates that use the format `2015-Nov-12`, but only supported dates like `2015-11-12`.

#### Where should the reviewer start?

- `DateMixin.js:_getMonth()`
- `DateMixin.js:_objectFromYearFirstDate`
- `DateMixin.js: _objectFromMonthFirstDate` 

#### How should this be manually tested?

See **Notes** field in the referenced defect.

#### What are the relevant tickets?

https://rally1.rallydev.com/#/23113539057d/detail/defect/48823082706

#### On-Demand

[Green on-demand](http://almci/job/on-demand/view/AppSDK-AppCatalog-ALM%20On-Demand%201/job/appsdk-appcatalog-alm-on-demand-1/2047/)

#### How does this PR make you feel? [:link:](http://giphy.com/categories/emotions/)

![bored](https://media.giphy.com/media/NWg7M1VlT101W/giphy.gif)