### PR TITLE
DE26870 - Milestones not selecable when project is "all projects in workspace"

### DIFF
--- a/src/apps/chartbuilder/EaselSettingsTransformer.js
+++ b/src/apps/chartbuilder/EaselSettingsTransformer.js
@@ -19,11 +19,10 @@
 					storeConfig: {
 						remoteFilter: true,
 						filters: [
-							Ext.create('Rally.data.wsapi.Filter', {
-								property: 'Projects.state',
-								operator: '=',
-								value: "Open"
-							})
+							Rally.data.wsapi.Filter.or([
+									{ property: 'TargetProject', operator: '=', value: null },
+									{ property: 'Projects.state', operator: '=', value: 'Open' }
+							])
 						]
 					}
 				};

--- a/test/spec/chartbuilder/EaselSettingsTransformerSpec.coffee
+++ b/test/spec/chartbuilder/EaselSettingsTransformerSpec.coffee
@@ -17,10 +17,7 @@ describe 'Rally.apps.chartbuilder.EaselSettingsTransformer', ->
 			filter: @stub()
 		]
 		@xformer = @createXformer()
-		@stub(Ext, 'create').withArgs('Rally.data.wsapi.Filter').returns(@filter);
-
-	afterEach ->
-		Ext.create.restore()
+		@stub(Rally.data.wsapi.Filter, 'or').returns(@filter)
 
 	it 'properly handles an empty settings fields list', ->
 		settingsFields = []


### PR DESCRIPTION
#### What does this PR do?

Adds Milestones that are not scoped to a particular project to still display in the dropdown list for the Milestone Burnup and Cumulative Flow apps

#### Any background context you want to provide?

This is a regression from the fix for DE26292

#### Where should the reviewer start?

src/apps/chartbuilder/EaselSettingsTransformer.js

#### How should this be manually tested?

See Defect details for how to test.

#### What are the relevant tickets?

DE26870

#### Screenshots, if appropriate.

N/A

#### Definition of Done
* [ ] Story __acceptance criteria__ updated if changed
* [ ] Does not negatively impact [__perceived performance__](https://docs.google.com/document/d/1j4AbGqGp_Le1SfQp3lp-pclk0ojQqZy7Cp-HbNq4i94)
* [ ] Does not degrade __performance__ and meets feature performance requirements
* [ ] Renders properly in [__all supported browsers__](https://help.rallydev.com/supported-web-browsers)
* [ ] __Sufficiently rich data__ used during development to expose important data relationships
* [ ] Numbers, dates, and strings visible to users use i18n formatting
* [ ] __Code reviewed__ by someone who didn't write it
* [ ] __Automated tests__ written and passing at appropriate levels. (unit, integration, end-to-end, etc.)
* [ ] No functional __regressions__ have been introduced

#### How does this PR make you feel? 
![](http://i.giphy.com/3oEdv9HWXUUUd44Cc0.gif)
